### PR TITLE
chore: Update test script to  work on NodeJS v22

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,14 @@
   "[html]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "editor.formatOnSave": true
   },
   "[typescript][jsonc]": {
     "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "editor.formatOnSave": true
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "pretest": "node ./build/test-build.mjs",
-    "test": "start-server-and-test 'node tests/serve.mjs' 3000 'node --test --experimental-test-coverage tests/node'",
+    "test": "start-server-and-test 'node tests/serve.mjs' 3000 'node --test --experimental-test-coverage tests/node/**/*.test.mjs'",
     "prepublishOnly": "npm test",
     "prepare": "npm run build",
     "preversion": "npm test"


### PR DESCRIPTION
This updates the "test" script because as it was it wasn't working on Node v22.  The settings.json package updated automatically for me, so I figured I should also push the changes.

**Note**:  VS Code makes the values "rvest.vs-code-prettier-eslint" and "esbenp.prettier-vscode" in settings.json as invalid.  I'm not an eslint guy, so unsure what should go there.