### PR TITLE
chore: Add publint and fix issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.1",
         "prettier": "^3.5.3",
+        "publint": "^0.3.10",
         "rimraf": "^6.0.1",
         "serve": "^14.2.4",
         "start-server-and-test": "^2.0.11",
@@ -695,6 +696,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.2.tgz",
+      "integrity": "sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@sideway/address": {
@@ -2759,6 +2773,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2889,6 +2913,13 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.1.0.tgz",
+      "integrity": "sha512-Y8f9qUlBzW8qauJjd/eu6jlpJZsuPJm2ZAV0cDVd420o4EdpH5RPdoCv+60/TdJflGatr4sDfpAL6ArWZbM5tA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2976,6 +3007,13 @@
         "through": "~2.3"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3036,6 +3074,28 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/publint": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.10.tgz",
+      "integrity": "sha512-xl9X9x0iyOURsAD7IPQJAQ5TgGpozs5K8KUtqzQBSxJqtKH74ReeCpjr2jw9MFOsY9q/EbXSJNkSFM2mgyu38g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.2",
+        "package-manager-detector": "^1.1.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/punycode": {
@@ -3212,6 +3272,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "scripts": {
     "start": "rimraf dist && node ./build/start.mjs",
     "build": "rimraf dist && node ./build/build.mjs",
-    "postbuild": "tsc && publint",
+    "postbuild": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "pretest": "node ./build/test-build.mjs",
     "test": "start-server-and-test 'node tests/serve.mjs' 3000 'node --test --experimental-test-coverage tests/node/**/*.test.mjs'",
-    "prepublishOnly": "npm test",
+    "prepublishOnly": "npm test && publint",
     "prepare": "npm run build",
     "preversion": "npm test"
   },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -16,12 +17,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "github:teil-one/fetch-api-progress"
+    "url": "git+https://github.com/teil-one/fetch-api-progress.git"
   },
   "scripts": {
     "start": "rimraf dist && node ./build/start.mjs",
     "build": "rimraf dist && node ./build/build.mjs",
-    "postbuild": "tsc",
+    "postbuild": "tsc && publint",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier": "prettier . --check",
@@ -56,6 +57,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.1",
     "prettier": "^3.5.3",
+    "publint": "^0.3.10",
     "rimraf": "^6.0.1",
     "serve": "^14.2.4",
     "start-server-and-test": "^2.0.11",


### PR DESCRIPTION
This PR adds publint to the building pipeline, and corrects the current issues.

The project's current publint results:

```plaintext
Errors:
1. pkg.exports["."].types should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.
Warnings:
1. pkg.repository.url is github:teil-one/fetch-api-progress which isn't a valid git URL. A valid git URL is usually in the form of "git+https://example.com/user/repo.git".
2. pkg.exports["."].types types is interpreted as ESM when resolving with the "require" condition. This causes the types to only work when dynamically importing the package, even though the package exports CJS. Consider splitting out two "types" conditions for "import" and "require", and use the .cts extension, e.g. pkg.exports["."].require.types: "./dist/index.d.cts"
```

After this PR, `publint` reports zero problems.